### PR TITLE
Add Header options from docs

### DIFF
--- a/itop/etc/apache2/conf-available/security.conf
+++ b/itop/etc/apache2/conf-available/security.conf
@@ -3,3 +3,9 @@
 </Directory>
 
 php_flag session.cookie_httponly on
+Header always set X-Frame-Options "sameorigin"
+Header always set X-Content-Type-Options "nosniff"
+ 
+# only for https:
+# Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains;" 
+# php_flag session.cookie_secure on


### PR DESCRIPTION
Fixes #1 
Adds the Header options from https://www.itophub.io/wiki/page?id=3_0_0%3Ainstall%3Asecurity#secure_critical_directories_access